### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/push-ecs.yml
+++ b/.github/workflows/push-ecs.yml
@@ -21,7 +21,7 @@ jobs:
           aws-region: ap-northeast-2
 
       - name: Build, tag, and push image to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ secrets.DOCKER_USERNAME }}/creatordetail
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore